### PR TITLE
removing redundancy from a few func names

### DIFF
--- a/fake_timer/fake_timer.go
+++ b/fake_timer/fake_timer.go
@@ -11,7 +11,7 @@ type FakeTimer struct {
 	afterRequests []afterRequest
 }
 
-func NewFakeTimer(now time.Time) *FakeTimer {
+func New(now time.Time) *FakeTimer {
 	return &FakeTimer{now: now}
 }
 

--- a/timer.go
+++ b/timer.go
@@ -11,7 +11,7 @@ type Timer interface {
 
 type realTimer struct{}
 
-func NewTimer() Timer {
+func New() Timer {
 	return &realTimer{}
 }
 


### PR DESCRIPTION
instead of `timer.NewTimer()`, making it `timer.New()`. same with `fake_timer`
